### PR TITLE
added truncation length to AuthProtocol, adapted hmac truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 src/private
+.idea


### PR DESCRIPTION
Fixes #13

allows for correct hmac truncation depending on the protocol used.

i have tested this successfully with a local snmpd using v3::AuthProtocol::Sha512 and v3::Cipher::Aes128.