### PR TITLE
Add support for custom SNMPv3 Context Name

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -251,6 +251,7 @@ pub struct Security {
     pub(crate) key_extension_method: Option<KeyExtension>,
     pub(crate) authoritative_state: AuthoritativeState,
     pub(crate) plain_buf: Vec<u8>,
+    pub(crate) context_name: Vec<u8>,
 }
 
 impl Security {
@@ -263,6 +264,7 @@ impl Security {
             key_extension_method: None,
             authoritative_state: AuthoritativeState::default(),
             plain_buf: Vec::new(),
+            context_name: Vec::new(),
         }
     }
 
@@ -273,6 +275,11 @@ impl Security {
 
     pub fn with_auth_protocol(mut self, auth_protocol: AuthProtocol) -> Self {
         self.auth_protocol = auth_protocol;
+        self
+    }
+
+    pub fn with_context_name(mut self, context_name: &str) -> Self {
+        self.context_name = context_name.as_bytes().to_vec();
         self
     }
 
@@ -957,7 +964,7 @@ pub(crate) fn build(
         let mut pdu_buf = Buf::default();
         pdu_buf.push_sequence(|buf| {
             pdu::build_inner(req_id, ident, values, max_repetitions, non_repeaters, buf);
-            buf.push_octet_string(&[]);
+            buf.push_octet_string(&security.context_name);
             buf.push_octet_string(security.engine_id());
         });
         let (encrypted, salt) = security.encrypt(&pdu_buf)?;
@@ -973,7 +980,7 @@ pub(crate) fn build(
         } else {
             buf.push_sequence(|buf| {
                 pdu::build_inner(req_id, ident, values, max_repetitions, non_repeaters, buf);
-                buf.push_octet_string(&[]);
+                buf.push_octet_string(&security.context_name);
                 buf.push_octet_string(security.engine_id());
             });
         }


### PR DESCRIPTION
Enables configuration of the **contextName** as defined in [RFC 3411](https://www.ietf.org/rfc/rfc3411.txt?number=3411) (Section 3.3.1).

Previously, this was hardcoded to an empty string (default context), preventing access to specific management contexts (e.g., printers, VRFs, VLANs, or specific hardware modules).

**Changes:**

- Added `context_name` field to `Security` struct.
- Added public `with_context_name` builder method.
- Updated `ScopedPDU` builder to use the provided context.