### PR TITLE
Mib types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ features = ["full"]
 features = ["full", "tokio"]
 
 [dependencies]
-asn1-rs = "0.6"
-snmptools = { version = "^0.1.2", optional = true }
+asn1-rs = "0.7.1"
+snmptools = { version = "^0.3.0", optional = true}
 tokio = { version = "1.47", features = ["net"], optional = true }
 openssl = { version = "0.10", optional = true }
 

--- a/src/asyncsession.rs
+++ b/src/asyncsession.rs
@@ -133,9 +133,10 @@ impl AsyncSession {
             if let Err(e) = Pdu::from_bytes_inner(
                 Self::send_and_recv(&self.socket, &self.send_pdu, &mut self.recv_buf).await?,
                 Some(security),
-            ) && e != Error::AuthUpdated
-            {
-                return Err(e);
+            ) {
+                if e != Error::AuthUpdated {
+                    return Err(e);
+                }
             }
             if security.need_init() {
                 return Err(Error::AuthFailure(v3::AuthErrorKind::NotAuthenticated));
@@ -155,12 +156,12 @@ impl AsyncSession {
     /// 'Err(error)' when 'init()' failed with error returned from 'init()'
     #[cfg(feature = "v3")]
     pub async fn try_another_key_extension_method(&mut self) -> Result<Option<v3::KeyExtension>> {
-        if let Some(ref mut security) = self.security
-            && let Some(new_method) = security.another_key_extension_method()
-        {
-            security.authoritative_state = v3::AuthoritativeState::default();
-            self.init().await?;
-            return Ok(Some(new_method));
+        if let Some(ref mut security) = self.security {
+            if let Some(new_method) = security.another_key_extension_method() {
+                security.authoritative_state = v3::AuthoritativeState::default();
+                self.init().await?;
+                return Ok(Some(new_method));
+            }
         }
         Ok(None)
     }

--- a/src/mibs.rs
+++ b/src/mibs.rs
@@ -12,6 +12,7 @@ pub trait MibConversion {
     fn from_mib_name(name: &str) -> Result<Self>
     where
         Self: Sized;
+    fn asn_type(&self) -> Result<u8>;
 }
 
 impl MibConversion for Oid<'_> {
@@ -26,5 +27,15 @@ impl MibConversion for Oid<'_> {
         Ok(snmptools::get_oid(name)
             .map_err(move |e| crate::Error::Mib(e.to_string()))?
             .to_owned())
+    }
+
+    fn asn_type(&self) -> Result<u8> {
+        let val = snmptools::get_type(self).map_err(|e| crate::Error::Mib(e.to_string()))?;
+        if val == 255 {
+            return Err(crate::Error::Mib(
+                format! {"netsnmp:mib_to_asn_type returned 255 (not found) for {self}"},
+            ));
+        }
+        Ok(val)
     }
 }

--- a/src/syncsession.rs
+++ b/src/syncsession.rs
@@ -164,9 +164,10 @@ impl SyncSession {
             if let Err(e) = Pdu::from_bytes_inner(
                 Self::send_and_recv(&self.socket, &self.send_pdu, &mut self.recv_buf)?,
                 Some(security),
-            ) && e != Error::AuthUpdated
-            {
-                return Err(e);
+            ) {
+                if e != Error::AuthUpdated {
+                    return Err(e);
+                }
             }
             if security.need_init() {
                 return Err(Error::AuthFailure(v3::AuthErrorKind::NotAuthenticated));
@@ -186,12 +187,12 @@ impl SyncSession {
     /// 'Err(error)' when 'init()' failed with error returned from 'init()'
     #[cfg(feature = "v3")]
     pub fn try_another_key_extension_method(&mut self) -> Result<Option<v3::KeyExtension>> {
-        if let Some(ref mut security) = self.security
-            && let Some(new_method) = security.another_key_extension_method()
-        {
-            security.authoritative_state = v3::AuthoritativeState::default();
-            self.init()?;
-            return Ok(Some(new_method));
+        if let Some(ref mut security) = self.security {
+            if let Some(new_method) = security.another_key_extension_method() {
+                security.authoritative_state = v3::AuthoritativeState::default();
+                self.init()?;
+                return Ok(Some(new_method));
+            }
         }
         Ok(None)
     }

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -301,12 +301,13 @@ impl Security {
     }
 
     pub(crate) fn another_key_extension_method(&mut self) -> Option<KeyExtension> {
-        if let Auth::AuthPriv { ref cipher, .. } = self.auth
-            && cipher.priv_key_needs_extension(&self.auth_protocol)
-            && let Some(used_method) = self.key_extension_method
-        {
-            self.key_extension_method = Some(used_method.other());
-            return self.key_extension_method;
+        if let Auth::AuthPriv { ref cipher, .. } = self.auth {
+            if cipher.priv_key_needs_extension(&self.auth_protocol) {
+                if let Some(used_method) = self.key_extension_method {
+                    self.key_extension_method = Some(used_method.other());
+                    return self.key_extension_method;
+                }
+            }
         }
         None
     }


### PR DESCRIPTION

I added fn asn_type to trait MibConvertion.
It uses fn snmptools::get_type that i added in pull request to snmptypes.


Besides:
I aligned asn1-rs in both crates snmptools and snmp 2 to 0.7.1
I fixed code not valid in edition 2024. (Code with wrong syntax compiled when compiling just snmp2 lib, but produced error if snmp2 was used as dependency in other rust crate with edition 2024).

I didn't change snmp2 ver number. I leave it to you.

I did this merge request because i need to get the information about expected oid types from mib files.