### PR TITLE
fix(v3): skip padding check in DES decryption

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -681,18 +681,7 @@ impl Security {
                 decryptor.decrypt_block_mut(block);
             }
 
-            if let Some(&pad_len) = self.plain_buf.last() {
-                let pad_len = pad_len as usize;
-                if pad_len > 0 && pad_len <= block_size && pad_len <= self.plain_buf.len() {
-                    let new_len = self.plain_buf.len() - pad_len;
-                    self.plain_buf.truncate(new_len);
-                    Ok(())
-                } else {
-                    Err(Error::Crypto("Invalid padding".into()))
-                }
-            } else {
-                Ok(())
-            }
+            Ok(())
         }
     }
 


### PR DESCRIPTION
Hi, I have fix (or workaround?) an issue about cyrpto-rust feature,
it happens on Cisco SG300 switch, which is only supports DES priv mode.
this switch is padding with 0, not PKCS-like scheme.

after I take a look at RFC3414, in 8.1.1.2, it mentioned "The actual pad value is irrelevant."
so I remove whole PKCS padding stub in `fn decrypt_des()`

below is the screenshot of Wireshark, I have censored something might sensitive.
<img width="1606" height="584" alt="wireshark" src="https://github.com/user-attachments/assets/8b8ff377-949c-47b7-8fac-b33b19342139" />
