### PR TITLE
Fix E0034 Hmac::update ambiguity under downstream feature unification

### DIFF
--- a/src/v3.rs
+++ b/src/v3.rs
@@ -356,37 +356,37 @@ impl Security {
                 AuthProtocol::Md5 => {
                     let mut mac = Hmac::<md5::Md5>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
                 AuthProtocol::Sha1 => {
                     let mut mac = Hmac::<sha1::Sha1>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
                 AuthProtocol::Sha224 => {
                     let mut mac = Hmac::<sha2::Sha224>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
                 AuthProtocol::Sha256 => {
                     let mut mac = Hmac::<sha2::Sha256>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
                 AuthProtocol::Sha384 => {
                     let mut mac = Hmac::<sha2::Sha384>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
                 AuthProtocol::Sha512 => {
                     let mut mac = Hmac::<sha2::Sha512>::new_from_slice(key)
                         .map_err(|_| Error::Crypto("Invalid key length".into()))?;
-                    mac.update(data);
+                    Mac::update(&mut mac, data);
                     Ok(mac.finalize().into_bytes().to_vec())
                 }
             }


### PR DESCRIPTION
`calculate_hmac` calls `mac.update(data)` with both `hmac::Mac` and `digest::DynDigest` in scope. `Hmac<D>` always implements `Mac`; it *also* matches `DynDigest`'s blanket impl — `impl<D: Update + FixedOutputReset + Reset + Clone + 'static> DynDigest for D` — once `hmac`'s `reset` feature is enabled, since that's what gives `Hmac` its `Reset`/`FixedOutputReset` impls. Both traits expose `update(&mut self, &[u8])`, so the bare call is ambiguous.

snmp2 builds standalone, but any dependency graph that turns on `hmac/reset` (it's a common feature) makes all six HMAC arms fail:

```
error[E0034]: multiple applicable items in scope
  --> src/v3.rs:359:25
   = note: candidate #1 is defined in an impl of the trait `DynDigest` for the type `D`
   = note: candidate #2 is defined in an impl of the trait `Mac` for the type `T`
```

**Minimal reproducer** — two dependencies, then `cargo build`:

```toml
[dependencies]
snmp2 = { version = "0.5", features = ["v3"] }
hmac = { version = "0.12", features = ["reset"] }
```

snmp2's own CI doesn't catch it because it builds the crate without `hmac/reset` on.

Qualifying the calls as `Mac::update(&mut mac, data)` resolves it — same `Update::update` the compiler picks anyway, no behaviour change. Only the `crypto-rust` path is touched.